### PR TITLE
Added abstract

### DIFF
--- a/lib/WWW/Google/Contacts.pm
+++ b/lib/WWW/Google/Contacts.pm
@@ -259,6 +259,10 @@ __PACKAGE__->meta->make_immutable;
 1;
 __END__
 
+=head1 NAME
+
+WWW::Google::Contacts - Google Contacts Data API
+
 =head1 SYNOPSIS
 
     use WWW::Google::Contacts;


### PR DESCRIPTION
Without this various tools can't find an abstract,
and for example MetaCPAN presents the module as a dist-relative path
rather than the module name.

You might want a Dist::Zilla plugin to generate this for you, but either way you need an abstract :-)
